### PR TITLE
Update nextcloud/server

### DIFF
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.2";
+  version = "31.0.3";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";


### PR DESCRIPTION
Automatically detected version bump of service `nextcloud/server`:
```diff
diff --git a/hosts/liskamm/nextcloud.nix b/hosts/liskamm/nextcloud.nix
index a6fc2d8..42167f6 100644
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.2";
+  version = "31.0.3";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";

```