### PR TITLE
Update immich-app/immich

### DIFF
--- a/hosts/liskamm/immich.nix
+++ b/hosts/liskamm/immich.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/immich-app/immich/releases
-  version = "v1.130.3";
+  version = "v1.131.3";
   port = 2283; # not exposed
   networkName = "immich";
   DB_DATABASE_NAME = "immich";


### PR DESCRIPTION
Automatically detected version bump of service `immich-app/immich`:
```diff
diff --git a/hosts/liskamm/immich.nix b/hosts/liskamm/immich.nix
index 8e0981f..ed40f1e 100644
--- a/hosts/liskamm/immich.nix
+++ b/hosts/liskamm/immich.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/immich-app/immich/releases
-  version = "v1.130.3";
+  version = "v1.131.3";
   port = 2283; # not exposed
   networkName = "immich";
   DB_DATABASE_NAME = "immich";

```