### PR TITLE
Update home-assistant/core

### DIFF
--- a/hosts/liskamm/home-assistant.nix
+++ b/hosts/liskamm/home-assistant.nix
@@ -8,7 +8,7 @@
 let
   # Check release notes
   # https://github.com/home-assistant/core/releases
-  version = "2025.4.2";
+  version = "2025.6.3";
   port = 8123; # not exposed
 in
 {


### PR DESCRIPTION
Automatically detected version bump of service `home-assistant/core`:
```diff
diff --git a/hosts/liskamm/home-assistant.nix b/hosts/liskamm/home-assistant.nix
index 2ef5ca4..8fc73d3 100644
--- a/hosts/liskamm/home-assistant.nix
+++ b/hosts/liskamm/home-assistant.nix
@@ -8,7 +8,7 @@
 let
   # Check release notes
   # https://github.com/home-assistant/core/releases
-  version = "2025.4.2";
+  version = "2025.6.3";
   port = 8123; # not exposed
 in
 {

```