### PR TITLE
Update nextcloud/server

### DIFF
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.6";
+  version = "31.0.7";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";


### PR DESCRIPTION
Automatically detected version bump of service `nextcloud/server`:
```diff
diff --git a/hosts/liskamm/nextcloud.nix b/hosts/liskamm/nextcloud.nix
index 63ce65b..39b7545 100644
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.6";
+  version = "31.0.7";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";

```
[All releases](https://github.com/nextcloud/server/releases)
[Release notes for 31.0.7](https://github.com/nextcloud/server/releases/tag/v31.0.7)