### PR TITLE
Update home-assistant/core

### DIFF
--- a/hosts/liskamm/home-assistant.nix
+++ b/hosts/liskamm/home-assistant.nix
@@ -8,7 +8,7 @@
 let
   # Check release notes
   # https://github.com/home-assistant/core/releases
-  version = "2025.7.1";
+  version = "2025.7.4";
   port = 8123; # not exposed
 in
 {


### PR DESCRIPTION
Automatically detected version bump of service `home-assistant/core`:
```diff
diff --git a/hosts/liskamm/home-assistant.nix b/hosts/liskamm/home-assistant.nix
index f58a4f7..1cdfb15 100644
--- a/hosts/liskamm/home-assistant.nix
+++ b/hosts/liskamm/home-assistant.nix
@@ -8,7 +8,7 @@
 let
   # Check release notes
   # https://github.com/home-assistant/core/releases
-  version = "2025.7.1";
+  version = "2025.7.4";
   port = 8123; # not exposed
 in
 {

```
[All releases](https://github.com/home-assistant/core/releases)
[Release notes for 2025.7.4](https://github.com/home-assistant/core/releases/tag/2025.7.4)