### PR TITLE
Update docker-mailserver/docker-mailserver

### DIFF
--- a/hosts/liskamm/mailserver.nix
+++ b/hosts/liskamm/mailserver.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/docker-mailserver/docker-mailserver/releases
-  version = "15.0.2";
+  version = "15.1.0";
   serverName = "mail.ncoding.at";
   webmailPort = 8000; # not exposed
   imapPort = 993;


### PR DESCRIPTION
Automatically detected version bump of service `docker-mailserver/docker-mailserver`:
```diff
diff --git a/hosts/liskamm/mailserver.nix b/hosts/liskamm/mailserver.nix
index 9fd7806..6692755 100644
--- a/hosts/liskamm/mailserver.nix
+++ b/hosts/liskamm/mailserver.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/docker-mailserver/docker-mailserver/releases
-  version = "15.0.2";
+  version = "15.1.0";
   serverName = "mail.ncoding.at";
   webmailPort = 8000; # not exposed
   imapPort = 993;

```
[All releases](https://github.com/docker-mailserver/docker-mailserver/releases)
[Release notes for 15.1.0](https://github.com/docker-mailserver/docker-mailserver/releases/tag/v15.1.0)