### PR TITLE
Update nextcloud/server

### DIFF
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.7";
+  version = "32.0.0";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";


### PR DESCRIPTION
Automatically detected version bump of service `nextcloud/server`:
```diff
diff --git a/hosts/liskamm/nextcloud.nix b/hosts/liskamm/nextcloud.nix
index 39b7545..bd01c4b 100644
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "31.0.7";
+  version = "32.0.0";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";

```
[All releases](https://github.com/nextcloud/server/releases)
[Release notes for 32.0.0](https://github.com/nextcloud/server/releases/tag/v32.0.0)