### PR TITLE
Update immich-app/immich

### DIFF
--- a/hosts/liskamm/immich.nix
+++ b/hosts/liskamm/immich.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/immich-app/immich/releases
-  version = "v2.2.2";
+  version = "v2.5.2";
   port = 2283; # not exposed
   networkName = "immich";
   DB_DATABASE_NAME = "immich";


### PR DESCRIPTION
Automatically detected version bump of service `immich-app/immich`:
```diff
diff --git a/hosts/liskamm/immich.nix b/hosts/liskamm/immich.nix
index 997a3d0..904a017 100644
--- a/hosts/liskamm/immich.nix
+++ b/hosts/liskamm/immich.nix
@@ -11,7 +11,7 @@
 let
   # Check release notes
   # https://github.com/immich-app/immich/releases
-  version = "v2.2.2";
+  version = "v2.5.2";
   port = 2283; # not exposed
   networkName = "immich";
   DB_DATABASE_NAME = "immich";

```
[All releases](https://github.com/immich-app/immich/releases)
[Release notes for v2.5.2](https://github.com/immich-app/immich/releases/tag/v2.5.2)