### PR TITLE
Update nextcloud/server

### DIFF
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "32.0.0";
+  version = "32.0.5";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";


### PR DESCRIPTION
Automatically detected version bump of service `nextcloud/server`:
```diff
diff --git a/hosts/liskamm/nextcloud.nix b/hosts/liskamm/nextcloud.nix
index bd01c4b..0d8c68b 100644
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "32.0.0";
+  version = "32.0.5";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";

```
[All releases](https://github.com/nextcloud/server/releases)
[Release notes for 32.0.5](https://github.com/nextcloud/server/releases/tag/v32.0.5)