### PR TITLE
Update nextcloud/server

### DIFF
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "32.0.5";
+  version = "33.0.2";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";


### PR DESCRIPTION
Automatically detected version bump of service `nextcloud/server`:
```diff
diff --git a/hosts/liskamm/nextcloud.nix b/hosts/liskamm/nextcloud.nix
index 0d8c68b..3946933 100644
--- a/hosts/liskamm/nextcloud.nix
+++ b/hosts/liskamm/nextcloud.nix
@@ -7,7 +7,7 @@
 let
   # Check release notes
   # https://github.com/nextcloud/server/releases
-  version = "32.0.5";
+  version = "33.0.2";
   port = 8001;
   networkName = "nextcloud";
   serverName = "nextcloud.ncoding.at";

```
[All releases](https://github.com/nextcloud/server/releases)
[Release notes for 33.0.2](https://github.com/nextcloud/server/releases/tag/v33.0.2)