### PR TITLE
Update dani-garcia/vaultwarden

### DIFF
--- a/hosts/liskamm/vaultwarden.nix
+++ b/hosts/liskamm/vaultwarden.nix
@@ -13,7 +13,7 @@
 let
   # Check release notes
   # https://github.com/dani-garcia/vaultwarden/releases
-  version = "1.35.8";
+  version = "1.37.0";
   port = 3876; # not exposed
   domain = "passwords.ncoding.at";
 in


### PR DESCRIPTION
Automatically detected version bump of service `dani-garcia/vaultwarden`:
```diff
diff --git a/hosts/liskamm/vaultwarden.nix b/hosts/liskamm/vaultwarden.nix
index a45c275..2de79d7 100644
--- a/hosts/liskamm/vaultwarden.nix
+++ b/hosts/liskamm/vaultwarden.nix
@@ -13,7 +13,7 @@
 let
   # Check release notes
   # https://github.com/dani-garcia/vaultwarden/releases
-  version = "1.35.8";
+  version = "1.37.0";
   port = 3876; # not exposed
   domain = "passwords.ncoding.at";
 in

```
[All releases](https://github.com/dani-garcia/vaultwarden/releases)
[Release notes for 1.37.0](https://github.com/dani-garcia/vaultwarden/releases/tag/1.37.0)